### PR TITLE
Add an option to use the swerve module class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
+    implementation "com.github.robototes:swerve-lib:aa8442ea29"
+
     testImplementation "junit:junit:4.12"
 }
 

--- a/src/main/java/dc/Mk4Configuration.java
+++ b/src/main/java/dc/Mk4Configuration.java
@@ -1,0 +1,47 @@
+package dc;
+
+import com.swervedrivespecialties.swervelib.Mk4SwerveModuleHelper;
+import com.swervedrivespecialties.swervelib.SwerveModule;
+
+public class Mk4Configuration {
+
+    private final Mk4SwerveModuleHelper.GearRatio ratio;
+    private final int drive, angle, encoder;
+    private final double offset;
+
+    public Mk4Configuration(Mk4SwerveModuleHelper.GearRatio rat, int dr, int ang, int enc, double off) {
+        ratio = rat;
+        drive = dr;
+        angle = ang;
+        encoder = enc;
+        offset = off;
+    }
+
+    public SwerveModule create() {
+        return create(true);
+    }
+
+    public SwerveModule create(boolean steer) {
+        return Mk4SwerveModuleHelper.createFalcon500(ratio, drive, angle, steer ? encoder : -1, steer ? offset : 0);
+    }
+
+    public Mk4SwerveModuleHelper.GearRatio getRatio() {
+        return ratio;
+    }
+
+    public int getDrive() {
+        return drive;
+    }
+
+    public int getAngle() {
+        return angle;
+    }
+
+    public int getEncoder() {
+        return encoder;
+    }
+
+    public double getOffset() {
+        return offset;
+    }
+}

--- a/src/main/java/dc/Robot.java
+++ b/src/main/java/dc/Robot.java
@@ -184,13 +184,13 @@ public class Robot extends TimedRobot {
 
       WPI_TalonFX frontRightMotor = (WPI_TalonFX) frontRightModule.getDriveMotor();
       frontRightMotor.setSensorPhase(false);
-      rightEncoderPosition = () -> frontRightMotor.getSelectedSensorPosition(PIDIDX) * encoderConstant;
-      rightEncoderRate = () -> frontRightMotor.getSelectedSensorVelocity(PIDIDX) * encoderConstant * 10;
+      rightEncoderPosition = () -> frontRightMotor.getSelectedSensorPosition(PIDIDX) * FRONT_LEFT_CONFIG.getRatio().getConfiguration().getDriveReduction() / ENCODER_EDGES_PER_REV;
+      rightEncoderRate = () -> frontRightMotor.getSelectedSensorVelocity(PIDIDX) * 10.0 * FRONT_LEFT_CONFIG.getRatio().getConfiguration().getDriveReduction() / ENCODER_EDGES_PER_REV;
 
       WPI_TalonFX frontLeftMotor = (WPI_TalonFX) frontLeftModule.getDriveMotor();
       frontLeftMotor.setSensorPhase(false);
-      leftEncoderPosition = () -> frontLeftMotor.getSelectedSensorPosition(PIDIDX) * encoderConstant;
-      leftEncoderRate = () -> frontLeftMotor.getSelectedSensorVelocity(PIDIDX) * encoderConstant * 10;
+      leftEncoderPosition = () -> frontLeftMotor.getSelectedSensorPosition(PIDIDX) * FRONT_LEFT_CONFIG.getRatio().getConfiguration().getDriveReduction() / ENCODER_EDGES_PER_REV;
+      leftEncoderRate = () -> frontLeftMotor.getSelectedSensorVelocity(PIDIDX) * 10.0 * FRONT_LEFT_CONFIG.getRatio().getConfiguration().getDriveReduction() / ENCODER_EDGES_PER_REV;
     } else {
       // create left motor
       WPI_TalonFX leftMotor = setupWPI_TalonFX(1, Sides.LEFT, true);


### PR DESCRIPTION
Add an option to use the swerve module class to control the motors & read the wheel positions (See `USE_MODULES`)
Also adds a boolean to switch between the competition robot & the swerve drivebase (See `IS_COMPETITION`)